### PR TITLE
Hook up tests

### DIFF
--- a/src/test/java/CoreTests.java
+++ b/src/test/java/CoreTests.java
@@ -1,0 +1,32 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package xquery;
+
+import org.exist.test.runner.XSuite;
+import org.junit.runner.RunWith;
+
+@RunWith(XSuite.class)
+@XSuite.XSuiteFiles({
+    "src/test/xquery"
+})
+public class CoreTests {
+}

--- a/src/test/xquery/sort.xqm
+++ b/src/test/xquery/sort.xqm
@@ -37,6 +37,7 @@ declare
 	%test:assertEquals(
 	    "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
 	    "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11",
+	    "this should trigger a test failure - if mvn test is working",
 	    "1.0.0-rc.1", "1.0.0", "2.0.0", "2.1.0", "2.1.1")
 function sts:sort() {
 	let $versions :=


### PR DESCRIPTION
... so that `mvn test` actually executes the XQuery tests.

To make sure the tests are actually running, I added a failing test to the PR, which I will remove when we can confirm that tests are actually running. Unfortunately, at the moment, the PR doesn't appear to be running the tests:

```
% mvn test
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------------< org.exist-db.xquery:semver-xq >--------------------
[INFO] Building semver.xq 2.3.1-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.2:enforce (enforce-maven) @ semver-xq ---
[INFO] 
[INFO] --- buildversion-plugin:1.0.3:set-properties (default) @ semver-xq ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ semver-xq ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 0 resource
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ semver-xq ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ semver-xq ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/joe/workspace/semver.xq/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ semver-xq ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 1 source file to /Users/joe/workspace/semver.xq/target/test-classes
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ semver-xq ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.760 s
[INFO] Finished at: 2021-10-04T14:41:55-04:00
[INFO] ------------------------------------------------------------------------
```