### PR TITLE
Test against eXist-db 4, 5, and 6 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
       fail-fast: true
       matrix:
         jdk: ['8', '11']
+        exist-version: ['4.2.0', '5.1.0', '6.1.0-SNAPSHOT']
         os: [ubuntu-latest]
-        exist-version: ['4', '5']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -22,15 +22,17 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Maven Build (eXist-db 4.x.x)
-        run: mvn clean package -DskipTests
-        if: ${{ matrix.exist-version == '4' }}
-      - name: Maven Build (eXist-db 5.x.x)
-        run: mvn clean package -DskipTests -Pexistdb-5-or-newer
-        if: ${{ matrix.exist-version == '5' }}
-      - name: Test (eXist-db 4.x.x)
-        run: mvn verify
-        if: ${{ matrix.exist-version == '4' }}
-      - name: Test (eXist-db 5.x.x)
-        run: mvn verify -Pexistdb-5-or-newer
-        if: ${{ matrix.exist-version == '5' }}
+      - name: Maven Build
+        run: |
+          if [[ "${{ matrix.exist-version }}" == "4.2.0" ]]; then
+              mvn -V clean package -DskipTests
+          else
+              mvn -V clean package -DskipTests -Pexistdb-5-or-newer -Dexist.version=${{ matrix.exist-version }}
+          fi
+      - name: Test
+        run: |
+          if [[ "${{ matrix.exist-version }}" == "4.2.0" ]]; then
+              mvn verify
+          else
+              mvn verify -Pexistdb-5-or-newer -Dexist.version=${{ matrix.exist-version }}
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,18 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.exist-version }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.exist-version }}-maven
       - name: Maven Build
         run: |
           if [[ "${{ matrix.exist-version }}" == "4.2.0" ]]; then


### PR DESCRIPTION
Test suite does not run against eXist-db 6.0.1, but does run against 6.1.0-SNAPSHOT. So we should update this again when 6.1.0 is released.

**Note** that PR https://github.com/eXist-db/semver.xq/pull/14 should be merged before this PR.