### PR TITLE
Create a version which is compatible with eXist-db 4.2.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,13 @@ name: CI
 on: [push, pull_request]
 jobs:
   build:
-    name: Build and Test (${{ matrix.os }} / OpenJDK ${{ matrix.jdk }})
+    name: Build and Test (${{ matrix.os }} / JDK ${{ matrix.jdk }} / eXist-db ${{ matrix.exist-version }})
     strategy:
       fail-fast: true
       matrix:
         jdk: ['8', '11']
         os: [ubuntu-latest]
+        exist-version: ['4', '5']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +22,15 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Maven Build
+      - name: Maven Build (eXist-db 4.x.x)
         run: mvn clean package -DskipTests
-      - name: Test
+        if: ${{ matrix.exist-version == '4' }}
+      - name: Maven Build (eXist-db 5.x.x)
+        run: mvn clean package -DskipTests -Pexistdb-5-or-newer
+        if: ${{ matrix.exist-version == '5' }}
+      - name: Test (eXist-db 4.x.x)
         run: mvn verify
+        if: ${{ matrix.exist-version == '4' }}
+      - name: Test (eXist-db 5.x.x)
+        run: mvn verify -Pexistdb-5-or-newer
+        if: ${{ matrix.exist-version == '5' }}

--- a/pom.xml
+++ b/pom.xml
@@ -62,27 +62,9 @@
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
 
-        <exist.version>5.1.0</exist.version>
-
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/xquery/semver-xq</package-name>
     </properties>
-
-    <dependencies>
-        <!-- test dependencies -->
-        <dependency>
-            <!-- required at XQSuite test runtime -->
-            <groupId>org.exist-db</groupId>
-            <artifactId>exist-core</artifactId>
-            <version>${exist.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <reporting>
         <plugins>
@@ -135,6 +117,16 @@
             </testResource>
         </testResources>
 
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>com.mycila</groupId>
@@ -145,24 +137,6 @@
                         <owner>Joe Wicentowski</owner>
                     </properties>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <goals>
-                            <goal>analyze-only</goal>
-                        </goals>
-                        <configuration>
-                            <failOnWarning>true</failOnWarning>
-                            <ignoredUnusedDeclaredDependencies>
-                                <ignoredUnusedDeclaredDependency>org.exist-db:exist-optional</ignoredUnusedDeclaredDependency>
-                            </ignoredUnusedDeclaredDependencies>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -240,4 +214,108 @@
             <url>https://clojars.org/repo</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <profiles>
+
+        <profile>
+            <id>existdb-4</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <exist.version>4.2.0</exist.version>
+            </properties>
+            <repositories>
+                <repository>
+                    <id>spring</id>
+                    <url>https://repo.spring.io/milestone/</url>
+                </repository>
+            </repositories>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>analyze</id>
+                                <goals>
+                                    <goal>analyze-only</goal>
+                                </goals>
+                                <configuration>
+                                    <failOnWarning>true</failOnWarning>
+                                    <ignoredUnusedDeclaredDependencies>
+                                        <ignoredUnusedDeclaredDependency>org.exist-db:exist-expath</ignoredUnusedDeclaredDependency>
+                                    </ignoredUnusedDeclaredDependencies>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.exist-db</groupId>
+                    <artifactId>exist-testkit</artifactId>
+                    <version>${exist.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.exist-db</groupId>
+                    <artifactId>exist-expath</artifactId>
+                    <version>${exist.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>4.12</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>existdb-5-or-newer</id>
+            <properties>
+                <exist.version>5.0.0</exist.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>analyze</id>
+                                <goals>
+                                    <goal>analyze-only</goal>
+                                </goals>
+                                <configuration>
+                                    <failOnWarning>true</failOnWarning>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <!-- test dependencies -->
+                <dependency>
+                    <!-- required at XQSuite test runtime -->
+                    <groupId>org.exist-db</groupId>
+                    <artifactId>exist-core</artifactId>
+                    <version>${exist.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+    </profiles>
+
 </project>

--- a/src/test/resources-filtered/conf.xml
+++ b/src/test/resources-filtered/conf.xml
@@ -791,6 +791,9 @@
             </module>
             <module uri="http://exist-db.org/xquery/xmldb" class="org.exist.xquery.functions.xmldb.XMLDBModule"/>
 
+            <!-- Needed for XQSuite on eXist-db 4.x.x! -->
+            <module uri="http://expath.org/ns/http-client" class="org.expath.exist.HttpClientModule"/>
+
         </builtin-modules>
     </xquery>
 


### PR DESCRIPTION
Whilst semver.xq previously demands eXist-db 5.1.0 or higher, it can actually happily execute on eXist-db 4.x.x as well. This PR adds support (and CI tests) for eXist-db 4.x.x alongside 5.x.x.

By default semver.xq will now build for a minimum version of eXist-db 4.2.0.

----
**Note** This PR should be merged before https://github.com/eXist-db/semver.xq/pull/13