### PR TITLE
Fix an issue where `semver:sort#3` was not returning all results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <contributors>
         <contributor>
             <name>Adam Retter</name>
-            <email>adam@exist-db.org</email>
+            <email>adam@evolvedbinary.com</email>
         </contributor>
     </contributors>
 

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -454,9 +454,9 @@ declare function semver:sort($versions as xs:string+) as xs:string+ {
 declare function semver:sort($versions as xs:string+, $coerce as xs:boolean) as xs:string+ {
     let $parsed := $versions ! semver:parse(., $coerce)
     let $sorted := semver:sort-parsed($parsed)
-    let $serialized := $sorted ! semver:serialize(.)
+    for $s in $sorted
     return
-         $serialized
+        semver:serialize($s)
 };
 
 (:~ Sort arbitrary items by their SemVer strings (with an option to coerce invalid SemVer strings)
@@ -478,8 +478,10 @@ declare function semver:sort($items as item()*, $function as function(*), $coerc
                 }
     let $sorted-versions := semver:sort-parsed($items-with-version?parsed-version)
     for $sorted-version in $sorted-versions
+    for $item-with-version in $items-with-version
+    where semver:compare-parsed($item-with-version?parsed-version, $sorted-version) eq 0
     return
-        $items-with-version[fn:deep-equal(?parsed-version, $sorted-version)]?item
+        $item-with-version?item
 };
 
 (:~ Sort SemVer maps

--- a/src/test/xquery/sort.xqm
+++ b/src/test/xquery/sort.xqm
@@ -48,17 +48,27 @@ function sts:sort() {
 };
 
 declare
+    %test:assertEquals("1.1.1", "2.2.0", "3.0.0")
+function sts:sort-with-coercion() {
+    semver:sort(("1.1.1", "2.2", "3"), true())
+};
+
+declare
 	%test:assertEquals(
 	    "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
 	    "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11",
-	    "1.0.0-rc.1", "1.0.0", "2.0.0", "2.1.0", "2.1.1")
-function sts:sort-items() {
+	    "1.0.0-rc.1", "1.0.0", "1.1.1", "2.0.0", "2.1.0",
+	    "2.1.1", "2.2", "3")
+function sts:sort-items-with-coercion() {
 	let $packages :=
     	<packages>
             <package version="1.0.0"/>
+            <package version="1.1.1"/>
             <package version="2.0.0"/>
             <package version="2.1.0"/>
             <package version="2.1.1"/>
+            <package version="2.2"/>
+            <package version="3"/>
             <package version="1.0.0-alpha"/>
             <package version="1.0.0-alpha.1"/>
             <package version="1.0.0-alpha.beta"/>
@@ -71,4 +81,3 @@ function sts:sort-items() {
         semver:sort($packages/package, function($item) { $item/@version }, true()) ! 
             ./@version/string()
 };
-


### PR DESCRIPTION
There was a bug in the `semver:sort#3` function where it would only return items if those items' unparsed version string matched the serialized coerced version string. The comparison should instead have been performed against coerced versions only (assuming the user had requested coercion).

I have tested that this works on the following eXist-db versions:
1. 4.2.0
2. 5.1.0
3. 6.1.0-SNAPSHOT
