### PR TITLE
Add handling for EXPath Package SemVer Templates

### DIFF
--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -629,7 +629,7 @@ declare function semver:sort($versions as xs:string+) as xs:string+ {
  :  @param $coerce An option for coercing non-SemVer version strings into parsable form
  :  @return A sequence of sorted version strings
  :)
-declare function semver:sort($versions as xs:string+, $coerce as xs:boolean) as xs:string+ {
+declare function semver:sort($versions as xs:string*, $coerce as xs:boolean) as xs:string* {
     let $parsed := $versions ! semver:parse(., $coerce)
     let $sorted := semver:sort-parsed($parsed)
     for $s in $sorted
@@ -666,7 +666,7 @@ declare function semver:sort($items as item()*, $function as function(*), $coerc
  :  @param $parsed-versions A sequence of SemVer maps, containing entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array
  :  @return A sorted sequence of SemVer maps, containing entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array
  :)
-declare %private function semver:sort-parsed($parsed-versions as map(*)+) as map(*)+ {
+declare function semver:sort-parsed($parsed-versions as map(*)*) as map(*)* {
     (: First, sort versions by major, minor, and patch (using fast standard sort) :)
     let $release-sorted := fn:sort($parsed-versions, (), function($p) { $p?major, $p?minor, $p?patch } )
     return

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -33,7 +33,6 @@ xquery version "3.1";
  :  not conform to the spec.
  :
  :  @author Joe Wicentowski
- :  @version 2.2.2
  :  @see https://semver.org/spec/v2.0.0.html
  :  @see https://gist.github.com/joewiz/b349e2853a17bf817e5d0013d01fa9f9
  :)

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -41,10 +41,26 @@ module namespace semver = "http://exist-db.org/xquery/semver";
 declare namespace array="http://www.w3.org/2005/xpath-functions/array";
 declare namespace map="http://www.w3.org/2005/xpath-functions/map";
 
-(:~ A regular expression for checking a SemVer version string 
- : @see https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+(:~ A regular expression for validating SemVer strings and parsing valid SemVer strings
+ :  
+ :  @see https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
  :)
-declare variable $semver:regex := "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
+declare variable $semver:regex :=
+    (: Start of string:)
+    "^"
+    (: Major version: A zero for initial development or a non-negative integer without leading zeros :)
+    || "(0|[1-9]\d*)"
+    (: `.` + Minor version: A zero or a non-negative integer without leading zeros :)
+    || "\.(0|[1-9]\d*)"
+    (: `.` + Patch version: A zero or a non-negative integer without leading zeros :)
+    || "\.(0|[1-9]\d*)"
+    (: `-` + Pre-release metadata (optional): A series of dot separated, non-empty identifiers, comprised only of ASCII alphanumerics and hyphens [0-9A-Za-z-] :)
+    || "(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    (: `+` + Build metadata (optional): A series of dot separated, non-empty identifiers, comprised only of ASCII alphanumerics and hyphens [0-9A-Za-z-] :)
+    || "(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+    (: End of string :)
+    || "$"
+;
 
 (:~ Validate whether a SemVer string conforms to the spec
  :  @param A version string

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -283,6 +283,16 @@ declare function semver:lt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
     semver:compare($v1, $v2, $coerce) eq -1
 };
 
+(:~ Test if a parsed v1 is a lower version than a parsed v2
+ :  
+ :  @param $v1 A parsed Semver version
+ :  @param $v2 A second parsed Semver version
+ :  @return true if v1 is less than v2
+ :)
+declare function semver:lt-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($v1, $v2) eq -1
+};
+
 (:~ Test if v1 is a lower version or the same version as v2 (strictly)
  :  
  :  @param $v1 A version string
@@ -304,6 +314,16 @@ declare function semver:le($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
     semver:compare($v1, $v2, $coerce) le 0
 };
 
+(:~ Test if a parsed v1 is a lower version or the same version as a parsed v2
+ :  
+ :  @param $v1 A parsed Semver version
+ :  @param $v2 A second parsed Semver version
+ :  @return true if v1 is less than or equal to v2
+ :)
+declare function semver:le-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($v1, $v2) le 0
+};
+
 (:~ Test if v1 is a higher version than v2 (strictly)
  :  @param $v1 A version string
  :  @param $v2 A second version string
@@ -321,6 +341,16 @@ declare function semver:gt($v1 as xs:string, $v2 as xs:string) as xs:boolean {
  :)
 declare function semver:gt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
     semver:compare($v1, $v2, $coerce) eq 1
+};
+
+(:~ Test if a parsed v1 is a higher version than a parsed v2
+ :  
+ :  @param $v1 A parsed Semver version
+ :  @param $v2 A second parsed Semver version
+ :  @return true if v1 is greater than v2
+ :)
+declare function semver:gt-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($v1, $v2) eq 1
 };
 
 (:~ Test if v1 is the same or higher version than v2 (strictly)
@@ -343,6 +373,16 @@ declare function semver:ge($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
     semver:compare($v1, $v2, $coerce) ge 0
 };
 
+(:~ Test if a parsed v1 is the same or higher version than a parsed v2
+ :  
+ :  @param $v1 A parsed Semver version
+ :  @param $v2 A second parsed Semver version
+ :  @return true if v1 is greater than or equal to v2
+ :)
+declare function semver:ge-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($v1, $v2) ge 0
+};
+
 (:~ Test if v1 is equal to v2 (strictly)
  :  
  :  @param $v1 A version string
@@ -361,6 +401,16 @@ declare function semver:eq($v1 as xs:string, $v2 as xs:string) as xs:boolean {
  :)
 declare function semver:eq($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
     semver:compare($v1, $v2) eq 0
+};
+
+(:~ Test if a parsed v1 is equal to a parsed v2
+ :  
+ :  @param $v1 A parsed Semver version
+ :  @param $v2 A second parsed Semver version
+ :  @return true if v1 is equal to v2
+ :)
+declare function semver:eq-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($v1, $v2) eq 0
 };
 
 (:~ Test if v1 is not equal to v2 (strictly)
@@ -382,6 +432,16 @@ declare function semver:ne($v1 as xs:string, $v2 as xs:string) as xs:boolean {
  :)
 declare function semver:ne($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
     semver:compare($v1, $v2, $coerce) ne 0
+};
+
+(:~ Test if a parsed v1 is not equal to a parsed v2
+ :  
+ :  @param $v1 A parsed Semver version
+ :  @param $v2 A second parsed Semver version
+ :  @return true if v1 is not equal to v2
+ :)
+declare function semver:ne-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($v1, $v2) ne 0
 };
 
 (:~ Compare release identifiers

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -34,7 +34,6 @@ xquery version "3.1";
  :
  :  @author Joe Wicentowski
  :  @see https://semver.org/spec/v2.0.0.html
- :  @see https://gist.github.com/joewiz/b349e2853a17bf817e5d0013d01fa9f9
  :)
 
 module namespace semver = "http://exist-db.org/xquery/semver";

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -174,7 +174,13 @@ declare function semver:coerce($version as xs:string) {
  :  @param $build-metadata Build identifiers
  :  @return A SemVer string
  :)
-declare function semver:serialize($major as xs:integer, $minor as xs:integer, $patch as xs:integer, $pre-release as xs:anyAtomicType*, $build-metadata as xs:anyAtomicType*) {
+declare function semver:serialize(
+    $major as xs:integer, 
+    $minor as xs:integer, 
+    $patch as xs:integer, 
+    $pre-release as xs:anyAtomicType*, 
+    $build-metadata as xs:anyAtomicType*
+) {
     let $release := string-join(($major, $minor, $patch), ".")
     let $pre-release := string-join($pre-release ! string(.), ".")
     let $build-metadata := string-join($build-metadata ! string(.), ".")

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -295,7 +295,7 @@ declare function semver:le($v1 as xs:string, $v2 as xs:string) as xs:boolean {
  :  @return true if v1 is less than or equal to v2
  :)
 declare function semver:le($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
-    semver:compare($v1, $v2, $coerce) = (-1, 0)
+    semver:compare($v1, $v2, $coerce) le 0
 };
 
 (:~ Test if v1 is a higher version than v2 (strictly)
@@ -334,7 +334,7 @@ declare function semver:ge($v1 as xs:string, $v2 as xs:string) as xs:boolean {
  :  @return true if v1 is greater than or equal to v2
  :)
 declare function semver:ge($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
-    semver:compare($v1, $v2, $coerce) = (1, 0)
+    semver:compare($v1, $v2, $coerce) ge 0
 };
 
 (:~ Test if v1 is equal to v2 (strictly)

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -50,7 +50,7 @@ declare namespace map="http://www.w3.org/2005/xpath-functions/map";
  :  @see https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
  :)
 declare variable $semver:regex :=
-    (: Start of string:)
+    (: Start of string :)
     "^"
     (: Major version: A zero for initial development or a non-negative integer without leading zeros :)
     || "(0|[1-9]\d*)"
@@ -66,9 +66,9 @@ declare variable $semver:regex :=
     || "$"
 ;
 
-(:~ A forgiving regular expression for capturing groups needed to coerce a non-SemVer string into a SemVer string :)
+(:~ A forgiving regular expression for capturing groups needed to coerce a non-SemVer string into SemVer components :)
 declare variable $semver:coerce-regex := 
-    (: Start of string:)
+    (: Start of string :)
     "^"
     (: Major version: One or more characters that are not `-`, `+`, or `.` :)
     || "([^-+.]+?)"
@@ -88,7 +88,7 @@ declare variable $semver:coerce-regex :=
  :  @see http://expath.org/spec/pkg#pkgdep
  :)
 declare variable $semver:expath-package-semver-template-regex :=
-    (: Start of string:)
+    (: Start of string :)
     "^"
     (: Major version: A zero for initial development or a non-negative integer without leading zeros :)
     || "(0|[1-9]\d*)"
@@ -688,7 +688,7 @@ declare %private function semver:sort-parsed($parsed-versions as map(*)+) as map
                 return
                     (
                         semver:sort-pre-release($pre-releases, ()),
-                        (: versions without pre-release metadata take precedence :)
+                        (: Versions without pre-release metadata take precedence :)
                         $releases
                     )
 };

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -170,7 +170,7 @@ declare function semver:parse($version as xs:string, $coerce as xs:boolean) as m
  :  @param $version A version string which will be coerced into a parsed SemVer version
  :  @return A map containing analysis of the coerced version, with entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array. Fallback for invalid version strings: 0.0.0.
  :)
-declare function semver:coerce($version as xs:string) {
+declare function semver:coerce($version as xs:string) as map(*) {
     let $analysis := analyze-string($version, $semver:coerce-regex)
     let $groups := $analysis/fn:match/fn:group
     let $release-identifiers := $groups[@nr = ("1", "2", "3")] ! replace(., "\D+", "") ! semver:cast-identifier(.)
@@ -748,7 +748,7 @@ declare %private function semver:error($code as xs:string, $version as xs:string
  :  @param $identifier An identifier
  :  return The identifier unchanged or cast as an integer
  :)
-declare %private function semver:cast-identifier($identifier as xs:string) {
+declare %private function semver:cast-identifier($identifier as xs:string) as xs:anyAtomicType {
     if ($identifier castable as xs:integer) then
         $identifier cast as xs:integer
     else
@@ -760,7 +760,7 @@ declare %private function semver:cast-identifier($identifier as xs:string) {
  :  @param $parsed-version A map containing analysis of a version string
  :  return The map with an identifiers entry
  :)
-declare %private function semver:populate-identifiers($parsed-version as map(*)) {
+declare %private function semver:populate-identifiers($parsed-version as map(*)) as map(*) {
     $parsed-version
     => map:put("identifiers", [ $parsed-version?major, $parsed-version?minor, $parsed-version?patch, $parsed-version?pre-release, $parsed-version?build-metadata ])
 };

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -179,10 +179,10 @@ declare function semver:serialize($major as xs:integer, $minor as xs:integer, $p
     let $pre-release := string-join($pre-release ! string(.), ".")
     let $build-metadata := string-join($build-metadata ! string(.), ".")
     let $candidate :=
-        $release ||
-        (if ($pre-release) then "-" || $pre-release else ()) ||
-        (if ($build-metadata) then "+" || $build-metadata else ())
-    (: raise an error if the candidate is invalid :)
+        $release
+        || (if ($pre-release) then "-" || $pre-release else ())
+        || (if ($build-metadata) then "+" || $build-metadata else ())
+    (: Raise an error if the candidate is invalid :)
     let $check := semver:parse($candidate)
     return
         $candidate

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -141,7 +141,6 @@ declare function semver:parse($version as xs:string) as map(*) {
  :  @error identifier-error
  :)
 declare function semver:parse($version as xs:string, $coerce as xs:boolean) as map(*) {
-    (: run the version against the standard SemVer regex :)
     let $analysis := analyze-string($version, $semver:regex)
     let $groups := $analysis/fn:match/fn:group
     return

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -657,7 +657,7 @@ declare function semver:sort($items as item()*, $function as function(*), $coerc
     let $sorted-versions := semver:sort-parsed($items-with-version?parsed-version)
     for $sorted-version in $sorted-versions
     for $item-with-version in $items-with-version
-    where semver:compare-parsed($item-with-version?parsed-version, $sorted-version) eq 0
+    where semver:eq-parsed($item-with-version?parsed-version, $sorted-version)
     return
         $item-with-version?item
 };

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -198,9 +198,25 @@ declare function semver:serialize(
  :  
  :  @param $parsed-version A map containing the components of the SemVer string
  :  @return A SemVer string
+ :  @deprecated As of 2.4.0 replace with serialize-parsed
  :)
-declare function semver:serialize($version as map(*)) {
-    semver:serialize($version?major, $version?minor, $version?patch, $version?pre-release, $version?build-metadata)
+declare function semver:serialize($parsed-version as map(*)) {
+    semver:serialize-parsed($parsed-version)
+};
+
+(:~ Serialize a parsed SemVer version
+ :  
+ :  @param $parsed-version A map containing the components of the SemVer string
+ :  @return A SemVer string
+ :)
+declare function semver:serialize-parsed($parsed-version as map(*)) {
+    semver:serialize(
+        $parsed-version?major, 
+        $parsed-version?minor, 
+        $parsed-version?patch, 
+        $parsed-version?pre-release, 
+        $parsed-version?build-metadata
+    )
 };
 
 (:~ Compare two versions (strictly)

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -528,12 +528,12 @@ declare %private function semver:error($code as xs:string, $version as xs:string
         map {
             "regex-error":
                 map {
-                    "description": "Version did not match regex for valid semver",
+                    "description": "Version did not match the regular expression for valid SemVer",
                     "qname": QName("http://joewiz.org/ns/xquery/semver", "regex-error")
                 },
             "identifier-error":
                 map {
-                    "description": "Version identifiers did not conform to semver spec",
+                    "description": "Version identifiers did not conform to SemVer spec",
                     "qname": QName("http://joewiz.org/ns/xquery/semver", "identifier-error")
                 }
         }

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -67,13 +67,7 @@ declare variable $semver:regex :=
  :  @return True if the version is valid, false if not
  :)
 declare function semver:validate($version as xs:string) as xs:boolean {
-    try {
-        let $parsed := semver:parse($version)
-        return
-            true()
-    } catch * {
-        false()
-    }
+    matches($version, $semver:regex)
 };
 
 (:~ Parse a SemVer version string (strictly)

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -353,6 +353,16 @@ declare function semver:eq($v1 as xs:string, $v2 as xs:string) as xs:boolean {
     semver:compare($v1, $v2) eq 0
 };
 
+(:~ Test if v1 is equal to v2 (with an option to coerce invalid SemVer strings)
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
+ :  @return true if v1 is equal to v2
+ :)
+declare function semver:eq($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
+    semver:compare($v1, $v2) eq 0
+};
+
 (:~ Test if v1 is not equal to v2 (strictly)
  :  
  :  @param $v1 A version string

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -326,8 +326,8 @@ declare function semver:serialize-parsed($parsed-version as map(*)) {
 
 (:~ Compare two versions (strictly)
  :  
- :  @param $v1 A version string
- :  @param $v2 A second version string
+ :  @param $parsed-v1 A version string
+ :  @param $parsed-v2 A second version string
  :  @return -1 if v1 < v2, 0 if v1 = v2, or 1 if v1 > v2.
  :)
 declare function semver:compare($v1 as xs:string, $v2 as xs:string) as xs:integer {
@@ -353,31 +353,31 @@ declare function semver:compare($v1 as xs:string, $v2 as xs:string, $coerce as x
 
 (:~ Compare two parsed SemVer versions
  :  
- :  @param $v1 A map containing analysis of a version string
- :  @param $v2 A map containing analysis of a second version string
+ :  @param $parsed-v1 A map containing analysis of a version string
+ :  @param $parsed-v2 A map containing analysis of a second version string
  :  @return -1 if v1 < v2, 0 if v1 = v2, or 1 if v1 > v2.
  :)
-declare function semver:compare-parsed($v1 as map(*), $v2 as map(*)) as xs:integer {
+declare function semver:compare-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:integer {
     (: Compare major, minor, and patch identifiers :)
     let $release-comparison :=
         semver:compare-release(
-            array:subarray($v1?identifiers, 1, 3),
-            array:subarray($v2?identifiers, 1, 3)
+            array:subarray($parsed-v1?identifiers, 1, 3),
+            array:subarray($parsed-v2?identifiers, 1, 3)
         )
     return
         switch ($release-comparison)
             case 0 return
                 (: When major, minor, and patch are equal, a pre-release version has lower precedence than a normal version. :)
-                if (array:size($v1?pre-release) eq 0 and array:size($v2?pre-release) gt 0) then
+                if (array:size($parsed-v1?pre-release) eq 0 and array:size($parsed-v2?pre-release) gt 0) then
                     1
-                else if (array:size($v1?pre-release) gt 0 and array:size($v2?pre-release) eq 0) then
+                else if (array:size($parsed-v1?pre-release) gt 0 and array:size($parsed-v2?pre-release) eq 0) then
                     -1
                 else
                     (: When major, minor, and patch are equal, compare pre-release :)
                     (: Build metadata SHOULD be ignored when determining version precedence. :)
                     semver:compare-pre-release(
-                        $v1?pre-release,
-                        $v2?pre-release
+                        $parsed-v1?pre-release,
+                        $parsed-v2?pre-release
                     )
             default return
                 $release-comparison
@@ -406,12 +406,12 @@ declare function semver:lt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 
 (:~ Test if a parsed v1 is a lower version than a parsed v2
  :  
- :  @param $v1 A parsed Semver version
- :  @param $v2 A second parsed Semver version
+ :  @param $parsed-v1 A parsed Semver version
+ :  @param $parsed-v2 A second parsed Semver version
  :  @return true if v1 is less than v2
  :)
-declare function semver:lt-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
-    semver:compare-parsed($v1, $v2) eq -1
+declare function semver:lt-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($parsed-v1, $parsed-v2) eq -1
 };
 
 (:~ Test if v1 is a lower version or the same version as v2 (strictly)
@@ -437,12 +437,12 @@ declare function semver:le($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 
 (:~ Test if a parsed v1 is a lower version or the same version as a parsed v2
  :  
- :  @param $v1 A parsed Semver version
- :  @param $v2 A second parsed Semver version
+ :  @param $parsed-v1 A parsed Semver version
+ :  @param $parsed-v2 A second parsed Semver version
  :  @return true if v1 is less than or equal to v2
  :)
-declare function semver:le-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
-    semver:compare-parsed($v1, $v2) le 0
+declare function semver:le-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($parsed-v1, $parsed-v2) le 0
 };
 
 (:~ Test if v1 is a higher version than v2 (strictly)
@@ -466,12 +466,12 @@ declare function semver:gt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 
 (:~ Test if a parsed v1 is a higher version than a parsed v2
  :  
- :  @param $v1 A parsed Semver version
- :  @param $v2 A second parsed Semver version
+ :  @param $parsed-v1 A parsed Semver version
+ :  @param $parsed-v2 A second parsed Semver version
  :  @return true if v1 is greater than v2
  :)
-declare function semver:gt-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
-    semver:compare-parsed($v1, $v2) eq 1
+declare function semver:gt-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($parsed-v1, $parsed-v2) eq 1
 };
 
 (:~ Test if v1 is the same or higher version than v2 (strictly)
@@ -496,12 +496,12 @@ declare function semver:ge($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 
 (:~ Test if a parsed v1 is the same or higher version than a parsed v2
  :  
- :  @param $v1 A parsed Semver version
- :  @param $v2 A second parsed Semver version
+ :  @param $parsed-v1 A parsed Semver version
+ :  @param $parsed-v2 A second parsed Semver version
  :  @return true if v1 is greater than or equal to v2
  :)
-declare function semver:ge-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
-    semver:compare-parsed($v1, $v2) ge 0
+declare function semver:ge-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($parsed-v1, $parsed-v2) ge 0
 };
 
 (:~ Test if v1 is equal to v2 (strictly)
@@ -526,12 +526,12 @@ declare function semver:eq($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 
 (:~ Test if a parsed v1 is equal to a parsed v2
  :  
- :  @param $v1 A parsed Semver version
- :  @param $v2 A second parsed Semver version
+ :  @param $parsed-v1 A parsed Semver version
+ :  @param $parsed-v2 A second parsed Semver version
  :  @return true if v1 is equal to v2
  :)
-declare function semver:eq-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
-    semver:compare-parsed($v1, $v2) eq 0
+declare function semver:eq-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($parsed-v1, $parsed-v2) eq 0
 };
 
 (:~ Test if v1 is not equal to v2 (strictly)
@@ -557,12 +557,12 @@ declare function semver:ne($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 
 (:~ Test if a parsed v1 is not equal to a parsed v2
  :  
- :  @param $v1 A parsed Semver version
- :  @param $v2 A second parsed Semver version
+ :  @param $parsed-v1 A parsed Semver version
+ :  @param $parsed-v2 A second parsed Semver version
  :  @return true if v1 is not equal to v2
  :)
-declare function semver:ne-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
-    semver:compare-parsed($v1, $v2) ne 0
+declare function semver:ne-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as xs:boolean {
+    semver:compare-parsed($parsed-v1, $parsed-v2) ne 0
 };
 
 (:~ Compare release identifiers
@@ -571,17 +571,17 @@ declare function semver:ne-parsed($v1 as map(*), $v2 as map(*)) as xs:boolean {
  :  @param $v2 A second array of release identifiers
  :  @return -1 if v1 < v2, 0 if v1 = v2, or 1 if v1 > v2.
  :)
-declare %private function semver:compare-release($v1 as array(*), $v2 as array(*)) {
+declare %private function semver:compare-release($v1-release-ids as array(*), $v2-release-ids as array(*)) {
     (: No (more) pairs to compare, so the release portions of the two versions are of equal precedence :)
-    if (array:size($v1) eq 0 and array:size($v2) eq 0) then
+    if (array:size($v1-release-ids) eq 0 and array:size($v2-release-ids) eq 0) then
         0
     (: Compare members using numeric operators :)
-    else if (array:head($v1) lt array:head($v2)) then
+    else if (array:head($v1-release-ids) lt array:head($v2-release-ids)) then
         -1
-    else if (array:head($v1) gt array:head($v2)) then
+    else if (array:head($v1-release-ids) gt array:head($v2-release-ids)) then
         1
     else
-        semver:compare-release(array:tail($v1), array:tail($v2))
+        semver:compare-release(array:tail($v1-release-ids), array:tail($v2-release-ids))
 };
 
 (:~ Compare pre-release identifiers
@@ -590,30 +590,29 @@ declare %private function semver:compare-release($v1 as array(*), $v2 as array(*
  :  @param $v2 A second array of pre-release identifiers
  :  @return -1 if v1 < v2, 0 if v1 = v2, or 1 if v1 > v2.
  :)
-declare %private function semver:compare-pre-release($v1 as array(*), $v2 as array(*)) {
+declare %private function semver:compare-pre-release($v1-pre-release-ids as array(*), $v2-pre-release-ids as array(*)) {
     (: No (more) pairs to compare, so the two versions are of equal precedence :)
-    if (array:size($v1) eq 0 and array:size($v2) eq 0) then
+    if (array:size($v1-pre-release-ids) eq 0 and array:size($v2-pre-release-ids) eq 0) then
         0
     (: A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal. :)
-    else if (array:size($v1) eq 0) then
+    else if (array:size($v1-pre-release-ids) eq 0) then
         -1
-    else if (array:size($v2) eq 0) then
+    else if (array:size($v2-pre-release-ids) eq 0) then
         1
     (: Numeric identifiers always have lower precedence than non-numeric identifiers. :)
-    else if (array:head($v1) instance of xs:string and array:head($v2) instance of xs:integer) then
+    else if (array:head($v1-pre-release-ids) instance of xs:string and array:head($v2-pre-release-ids) instance of xs:integer) then
         1
-    else if (array:head($v1) instance of xs:integer and array:head($v2) instance of xs:string) then
+    else if (array:head($v1-pre-release-ids) instance of xs:integer and array:head($v2-pre-release-ids) instance of xs:string) then
         -1
     (: Compare values using comparison operators :)
-    else if (array:head($v1) lt array:head($v2)) then
+    else if (array:head($v1-pre-release-ids) lt array:head($v2-pre-release-ids)) then
         -1
-    else if (array:head($v1) gt array:head($v2)) then
+    else if (array:head($v1-pre-release-ids) gt array:head($v2-pre-release-ids)) then
         1
     (: These identifiers are equal, so recurse to the next pair of identifiers :)
     else
-        semver:compare-pre-release(array:tail($v1), array:tail($v2))
+        semver:compare-pre-release(array:tail($v1-pre-release-ids), array:tail($v2-pre-release-ids))
 };
-
 
 (:~ Sort SemVer strings (strictly)
  :  

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -80,16 +80,18 @@ declare variable $semver:coerce-regex :=
     || "$";
 
 (:~ Validate whether a SemVer string conforms to the spec
- :  @param A version string
+ :  
+ :  @param $version A version string
  :  @return True if the version is valid, false if not
  :)
 declare function semver:validate($version as xs:string) as xs:boolean {
     matches($version, $semver:regex)
 };
 
-(:~ Parse a SemVer version string (strictly)
- :  @param A version string
- :  @return A map containing analysis of the parsed version, containing entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array.
+(:~ Parse a SemVer string (strictly)
+ :  
+ :  @param $version A version string
+ :  @return A map containing analysis of the parsed version, with entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array.
  :  @error regex-error
  :  @error identifier-error
  :)
@@ -97,10 +99,11 @@ declare function semver:parse($version as xs:string) as map(*) {
     semver:parse($version, false())
 };
 
-(:~ Parse a SemVer version string (with an option to coerce invalid SemVer strings)
- :  @param A version string
- :  @param An option for coercing non-SemVer version strings into parsable form
- :  @return A map containing analysis of the parsed version, containing entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array.
+(:~ Parse a SemVer string (with an option to coerce invalid SemVer strings)
+ :  
+ :  @param $version A version string
+ :  @param $coerce An option for coercing non-SemVer version strings into parsable form
+ :  @return A map containing analysis of the parsed SemVer versions, with entries for each identifier ("major", "minor", "patch", "pre-release", and "build-metadata"), and an "identifiers" entry with all identifiers in an array.
  :  @error regex-error
  :  @error identifier-error
  :)
@@ -163,11 +166,12 @@ declare function semver:coerce($version as xs:string) {
 };
 
 (:~ Serialize a SemVer string
- :  @param The major version
- :  @param The minor version
- :  @param The patch version
- :  @param Pre-release identifiers
- :  @param Build identifiers
+ :  
+ :  @param $major The major version
+ :  @param $minor The minor version
+ :  @param $patch The patch version
+ :  @param $pre-release Pre-release identifiers
+ :  @param $build-metadata Build identifiers
  :  @return A SemVer string
  :)
 declare function semver:serialize($major as xs:integer, $minor as xs:integer, $patch as xs:integer, $pre-release as xs:anyAtomicType*, $build-metadata as xs:anyAtomicType*) {
@@ -184,8 +188,9 @@ declare function semver:serialize($major as xs:integer, $minor as xs:integer, $p
         $candidate
 };
 
-(:~ Serialize a parsed SemVer string
- :  @param A map containing the components of the SemVer
+(:~ Serialize a parsed SemVer version
+ :  
+ :  @param $parsed-version A map containing the components of the SemVer string
  :  @return A SemVer string
  :)
 declare function semver:serialize($version as map(*)) {
@@ -193,8 +198,9 @@ declare function semver:serialize($version as map(*)) {
 };
 
 (:~ Compare two versions (strictly)
- :  @param A version string
- :  @param A second version string
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return -1 if v1 < v2, 0 if v1 = v2, or 1 if v1 > v2.
  :)
 declare function semver:compare($v1 as xs:string, $v2 as xs:string) as xs:integer {
@@ -205,9 +211,10 @@ declare function semver:compare($v1 as xs:string, $v2 as xs:string) as xs:intege
 };
 
 (:~ Compare two versions (with an option to coerce invalid SemVer strings)
- :  @param A version string
- :  @param A second version string
- :  @param An option for coercing non-SemVer version strings into parsable form
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
+ :  @param $coerce An option for coercing non-SemVer version strings into parsable form
  :  @return -1 if v1 < v2, 0 if v1 = v2, or 1 if v1 > v2.
  :)
 declare function semver:compare($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:integer {
@@ -250,8 +257,9 @@ declare function semver:compare-parsed($v1 as map(*), $v2 as map(*)) as xs:integ
 };
 
 (:~ Test if v1 is a lower version than v2 (strictly)
- :  @param A version string
- :  @param A second version string
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is less than v2
  :)
 declare function semver:lt($v1 as xs:string, $v2 as xs:string) as xs:boolean {
@@ -259,9 +267,10 @@ declare function semver:lt($v1 as xs:string, $v2 as xs:string) as xs:boolean {
 };
 
 (:~ Test if v1 is a lower version than v2 (with an option to coerce invalid SemVer strings)
- :  @param A version string
- :  @param A second version string
- :  @param An option for coercing non-SemVer version strings into parsable form
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
+ :  @param $coerce An option for coercing non-SemVer version strings into parsable form
  :  @return true if v1 is less than v2
  :)
 declare function semver:lt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
@@ -269,8 +278,9 @@ declare function semver:lt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 };
 
 (:~ Test if v1 is a lower version or the same version as v2 (strictly)
- :  @param A version string
- :  @param A second version string
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is less than or equal to v2
  :)
 declare function semver:le($v1 as xs:string, $v2 as xs:string) as xs:boolean {
@@ -278,9 +288,10 @@ declare function semver:le($v1 as xs:string, $v2 as xs:string) as xs:boolean {
 };
 
 (:~ Test if v1 is a lower version or the same version as v2 (with an option to coerce invalid SemVer strings)
- :  @param A version string
- :  @param A second version string
- :  @param An option for coercing non-SemVer version strings into parsable form
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
+ :  @param $coerce An option for coercing non-SemVer version strings into parsable form
  :  @return true if v1 is less than or equal to v2
  :)
 declare function semver:le($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
@@ -288,8 +299,8 @@ declare function semver:le($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 };
 
 (:~ Test if v1 is a higher version than v2 (strictly)
- :  @param A version string
- :  @param A second version string
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is greater than v2
  :)
 declare function semver:gt($v1 as xs:string, $v2 as xs:string) as xs:boolean {
@@ -297,8 +308,9 @@ declare function semver:gt($v1 as xs:string, $v2 as xs:string) as xs:boolean {
 };
 
 (:~ Test if v1 is a higher version than v2 (with an option to coerce invalid SemVer strings)
- :  @param A version string
- :  @param A second version string
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is greater than v2
  :)
 declare function semver:gt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
@@ -306,26 +318,29 @@ declare function semver:gt($v1 as xs:string, $v2 as xs:string, $coerce as xs:boo
 };
 
 (:~ Test if v1 is the same or higher version than v2 (strictly)
- :  @param A version string
- :  @param A second version string
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is greater than or equal to v2
  :)
 declare function semver:ge($v1 as xs:string, $v2 as xs:string) as xs:boolean {
     semver:ge($v1, $v2, false())
 };
 
-(:~ Test if v1 is the same or higher version than v2
- :  @param A version string
- :  @param A second version string
+(:~ Test if v1 is the same or higher version than v2 (with an option to coerce invalid SemVer strings)
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is greater than or equal to v2
  :)
 declare function semver:ge($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
     semver:compare($v1, $v2, $coerce) = (1, 0)
 };
 
-(:~ Test if v1 is equal to v2
- :  @param A version string
- :  @param A second version string
+(:~ Test if v1 is equal to v2 (strictly)
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is equal to v2
  :)
 declare function semver:eq($v1 as xs:string, $v2 as xs:string) as xs:boolean {
@@ -333,8 +348,9 @@ declare function semver:eq($v1 as xs:string, $v2 as xs:string) as xs:boolean {
 };
 
 (:~ Test if v1 is not equal to v2 (strictly)
- :  @param A version string
- :  @param A second version string
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
  :  @return true if v1 is not equal to v2
  :)
 declare function semver:ne($v1 as xs:string, $v2 as xs:string) as xs:boolean {
@@ -342,9 +358,10 @@ declare function semver:ne($v1 as xs:string, $v2 as xs:string) as xs:boolean {
 };
 
 (:~ Test if v1 is not equal to v2 (with an option to coerce invalid SemVer strings)
- :  @param A version string
- :  @param A second version string
- :  @param An option for coercing non-SemVer version strings into parsable form
+ :  
+ :  @param $v1 A version string
+ :  @param $v2 A second version string
+ :  @param $coerce An option for coercing non-SemVer version strings into parsable form
  :  @return true if v1 is not equal to v2
  :)
 declare function semver:ne($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
@@ -402,6 +419,7 @@ declare %private function semver:compare-pre-release($v1 as array(*), $v2 as arr
 
 
 (:~ Sort SemVer strings (strictly)
+ :  
  :  @param $versions A sequence of version strings
  :  @return A sequence of sorted version strings
  :)
@@ -410,6 +428,7 @@ declare function semver:sort($versions as xs:string+) as xs:string+ {
 };
 
 (:~ Sort SemVer strings (with an option to coerce invalid SemVer strings)
+ :  
  :  @param $versions A sequence of version strings
  :  @param $coerce An option for coercing non-SemVer version strings into parsable form
  :  @return A sequence of sorted version strings
@@ -479,6 +498,7 @@ declare %private function semver:sort-parsed($parsed-versions as map(*)+) as map
 };
 
 (:~ Sort pre-release fields
+ :  
  :  @param $parsed-versions The versions to sort
  :  @param $sorted-versions An accumulator for sorted versions
  :  @return Sorted versions
@@ -498,8 +518,9 @@ declare %private function semver:sort-pre-release($parsed-versions as map(*)*, $
 };
 
 (:~ Raise a descriptive error
- :  @param An error code
- :  @param The version or identifier that triggered the error
+ :  
+ :  @param $code An error code
+ :  @param $version The version or identifier that triggered the error
  :  @return The error.
  :)
 declare %private function semver:error($code as xs:string, $version as xs:string) {

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -41,9 +41,8 @@ module namespace semver = "http://exist-db.org/xquery/semver";
 declare namespace array="http://www.w3.org/2005/xpath-functions/array";
 declare namespace map="http://www.w3.org/2005/xpath-functions/map";
 
-(:~ A regular expression for checking a SemVer version string
- :  @author David Fichtmueller
- :  @see https://github.com/semver/semver/pull/460
+(:~ A regular expression for checking a SemVer version string 
+ : @see https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
  :)
 declare variable $semver:regex := "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
 

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -646,15 +646,15 @@ declare function semver:sort($versions as xs:string+, $coerce as xs:boolean) as 
  :)
 declare function semver:sort($items as item()*, $function as function(*), $coerce as xs:boolean) as item()* {
     let $items-with-version :=
-            for $item in $items
-            let $version-string := $function($item)
-            let $parsed-version := semver:parse($version-string, $coerce)
-            return
-                map {
-                    "item": $item,
-                    "version-string": $version-string,
-                    "parsed-version": $parsed-version
-                }
+        for $item in $items
+        let $version-string := $function($item)
+        let $parsed-version := semver:parse($version-string, $coerce)
+        return
+            map {
+                "item": $item,
+                "version-string": $version-string,
+                "parsed-version": $parsed-version
+            }
     let $sorted-versions := semver:sort-parsed($items-with-version?parsed-version)
     for $sorted-version in $sorted-versions
     for $item-with-version in $items-with-version

--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -62,6 +62,23 @@ declare variable $semver:regex :=
     || "$"
 ;
 
+(:~ A forgiving regular expression for capturing groups needed to coerce a non-SemVer string into a SemVer string :)
+declare variable $semver:coerce-regex := 
+    (: Start of string:)
+    "^"
+    (: Major version: One or more characters that are not `-`, `+`, or `.` :)
+    || "([^-+.]+?)"
+    (: `.` + Minor version: One or more characters that are not `-`, `+`, or `.` :)
+    || "(?:\.([^-+.]+?))?"
+    (: `.` + Patch version: One or more characters that are not `-`, `+`, or `.` :)
+    || "(?:\.([^-+.]+?))?"
+    (: `-` + Pre-release metadata (optional): One or more characters that are not `+` :)
+    || "(?:-([^+]+?))?"
+    (: `+` + Build metadata (optional): One or more characters :)
+    || "(?:\+(.+))?"
+    (: End of string :)
+    || "$";
+
 (:~ Validate whether a SemVer string conforms to the spec
  :  @param A version string
  :  @return True if the version is valid, false if not

--- a/src/test/xquery/coerce.xqm
+++ b/src/test/xquery/coerce.xqm
@@ -36,121 +36,121 @@ declare namespace test = "http://exist-db.org/xquery/xqsuite";
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="0" patch="0"/>',
-	    '<semver major="1" minor="0" patch="0"/>',
-	    '<semver major="4" minor="0" patch="0"/>',
-	    '<semver major="99999" minor="0" patch="0"/>'
+        '<semver major="0" minor="0" patch="0"/>',
+        '<semver major="1" minor="0" patch="0"/>',
+        '<semver major="4" minor="0" patch="0"/>',
+        '<semver major="99999" minor="0" patch="0"/>'
     )
 function stco:major() {
-	(
-	    "0",
-	    "1",
-	    "4",
-	    "99999"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0",
+        "1",
+        "4",
+        "99999"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="1" patch="0"/>',
-	    '<semver major="0" minor="4" patch="0"/>',
-	    '<semver major="1" minor="0" patch="0"/>',
-	    '<semver major="1" minor="1" patch="0"/>',
-	    '<semver major="1" minor="4" patch="0"/>'
+        '<semver major="0" minor="1" patch="0"/>',
+        '<semver major="0" minor="4" patch="0"/>',
+        '<semver major="1" minor="0" patch="0"/>',
+        '<semver major="1" minor="1" patch="0"/>',
+        '<semver major="1" minor="4" patch="0"/>'
     )
 function stco:major-minor() {
-	(
-	    "0.1",
-	    "0.4",
-	    "1.0",
-	    "1.1",
-	    "1.4"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0.1",
+        "0.4",
+        "1.0",
+        "1.1",
+        "1.4"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="0" patch="0"><pre-release>RC1</pre-release></semver>',
-	    '<semver major="1" minor="0" patch="0"><pre-release>SNAPSHOT</pre-release></semver>',
-	    '<semver major="4" minor="0" patch="0"><pre-release>alpha-beta</pre-release></semver>'
+        '<semver major="0" minor="0" patch="0"><pre-release>RC1</pre-release></semver>',
+        '<semver major="1" minor="0" patch="0"><pre-release>SNAPSHOT</pre-release></semver>',
+        '<semver major="4" minor="0" patch="0"><pre-release>alpha-beta</pre-release></semver>'
     )
 function stco:major-pre-release() {
-	(
-	    "0-RC1",
-	    "1-SNAPSHOT",
-	    "4-alpha-beta"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0-RC1",
+        "1-SNAPSHOT",
+        "4-alpha-beta"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="1" patch="0"><pre-release>SNAPSHOT</pre-release></semver>',
-	    '<semver major="0" minor="4" patch="0"><pre-release>RC9</pre-release></semver>',
-	    '<semver major="1" minor="0" patch="0"><pre-release>alpha</pre-release></semver>',
-	    '<semver major="1" minor="0" patch="0"><pre-release>alpha</pre-release><pre-release>beta</pre-release></semver>'
+        '<semver major="0" minor="1" patch="0"><pre-release>SNAPSHOT</pre-release></semver>',
+        '<semver major="0" minor="4" patch="0"><pre-release>RC9</pre-release></semver>',
+        '<semver major="1" minor="0" patch="0"><pre-release>alpha</pre-release></semver>',
+        '<semver major="1" minor="0" patch="0"><pre-release>alpha</pre-release><pre-release>beta</pre-release></semver>'
     )
 function stco:major-minor-pre-release() {
-	(
-	    "0.1-SNAPSHOT",
-	    "0.4-RC9",
-	    "1.0-alpha",
-	    "1.0-alpha.beta"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0.1-SNAPSHOT",
+        "0.4-RC9",
+        "1.0-alpha",
+        "1.0-alpha.beta"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="0" patch="0"><build-metadata>2019</build-metadata></semver>',
-	    '<semver major="1" minor="0" patch="0"><build-metadata>2019-08-09</build-metadata><build-metadata>2350</build-metadata></semver>'
+        '<semver major="0" minor="0" patch="0"><build-metadata>2019</build-metadata></semver>',
+        '<semver major="1" minor="0" patch="0"><build-metadata>2019-08-09</build-metadata><build-metadata>2350</build-metadata></semver>'
     )
 function stco:major-build-metadata() {
-	(
-	    "0+2019",
-	    "1+2019-08-09.2350"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0+2019",
+        "1+2019-08-09.2350"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="1" patch="1"/>',
-	    '<semver major="10" minor="4" patch="12"/>'
+        '<semver major="0" minor="1" patch="1"/>',
+        '<semver major="10" minor="4" patch="12"/>'
     )
 function stco:major-minor-patch() {
-	(
-	    "0.1.1",
-	    "10.4.012"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0.1.1",
+        "10.4.012"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="0" minor="1" patch="1"><pre-release>SNAPSHOT</pre-release></semver>',
-	    '<semver major="10" minor="4" patch="12"><pre-release>alpha-beta</pre-release></semver>',
-	    '<semver major="10" minor="4" patch="12"><pre-release>alpha</pre-release><pre-release>gamma</pre-release></semver>'
+        '<semver major="0" minor="1" patch="1"><pre-release>SNAPSHOT</pre-release></semver>',
+        '<semver major="10" minor="4" patch="12"><pre-release>alpha-beta</pre-release></semver>',
+        '<semver major="10" minor="4" patch="12"><pre-release>alpha</pre-release><pre-release>gamma</pre-release></semver>'
     )
 function stco:major-minor-patch-pre-release() {
-	(
-	    "0.1.1-SNAPSHOT",
-	    "10.4.012-alpha-beta",
-	    "10.4.012-alpha.gamma"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "0.1.1-SNAPSHOT",
+        "10.4.012-alpha-beta",
+        "10.4.012-alpha.gamma"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 declare
     %test:assertEquals
     (
-	    '<semver major="1" minor="2" patch="3"><pre-release>stuff</pre-release><pre-release>AND</pre-release><build-metadata>things-yeah</build-metadata><build-metadata>YES</build-metadata></semver>'
+        '<semver major="1" minor="2" patch="3"><pre-release>stuff</pre-release><pre-release>AND</pre-release><build-metadata>things-yeah</build-metadata><build-metadata>YES</build-metadata></semver>'
     )
 function stco:major-minor-patch-pre-release-build-metadata() {
-	(
-	    "1.2.3-stuff.AND+things-yeah.YES"
-	) ! stco:semver-to-xml(semver:coerce(.))
+    (
+        "1.2.3-stuff.AND+things-yeah.YES"
+    ) ! stco:semver-to-xml(semver:coerce(.))
 };
 
 

--- a/src/test/xquery/compare.xqm
+++ b/src/test/xquery/compare.xqm
@@ -41,8 +41,26 @@ function stc:lt-major() {
 
 declare
 	%test:assertEquals("true")
+function stc:lt-major-parsed() {
+	semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
+        map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
+    )
+};
+
+declare
+	%test:assertEquals("true")
 function stc:lt-minor() {
 	semver:lt("2.0.0", "2.1.0")
+};
+
+declare
+	%test:assertEquals("true")
+function stc:lt-minor-parsed() {
+	semver:lt-parsed(
+        map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
+        map{"major":2,"minor":1,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,1,0,[],[]]}
+    )
 };
 
 declare
@@ -53,8 +71,26 @@ function stc:lt-patch() {
 
 declare
 	%test:assertEquals("true")
+function stc:lt-patch-parsed() {
+	semver:lt-parsed(
+        map{"major":2,"minor":1,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
+        map{"major":2,"minor":1,"patch":1,"pre-release":[],"build-metadata":[],"identifiers":[2,1,1,[],[]]}
+    )
+};
+
+declare
+	%test:assertEquals("true")
 function stc:lt-pre-release() {
 	semver:lt("1.0.0-alpha", "1.0.0-alpha.1")
+};
+
+declare
+	%test:assertEquals("true")
+function stc:lt-pre-release-parsed() {
+	semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":["alpha"],"build-metadata":[],"identifiers":[2,0,0,["alpha"],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":["alpha",1],"build-metadata":[],"identifiers":[2,1,1,["alpha",1],[]]}
+    )
 };
 
 declare
@@ -68,9 +104,43 @@ function stc:lt-pre-release-dot() {
 };
 
 declare
+	%test:assertEquals("true", "true", "true", "true", "true")
+function stc:lt-pre-release-dot-parsed() {
+    semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":["alpha",1],"build-metadata":[],"identifiers":[1,0,0,["alpha",1],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":["alpha","beta"],"build-metadata":[],"identifiers":[1,0,0,["alpha","beta"],[]]}
+    ),
+    semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":["beta"],"build-metadata":[],"identifiers":[1,0,0,["alpha"],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":["beta",2],"build-metadata":[],"identifiers":[1,0,0,["beta",2],[]]}
+    ),
+    semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":["beta",1],"build-metadata":[],"identifiers":[1,0,0,["alpha"],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":["beta",11],"build-metadata":[],"identifiers":[1,0,0,["beta",11],[]]}
+    ),
+    semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":["beta",11],"build-metadata":[],"identifiers":[1,0,0,["alpha"],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":["rc",1],"build-metadata":[],"identifiers":[1,0,0,["rc",1],[]]}
+    ),
+    semver:lt-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":["rc",1],"build-metadata":[],"identifiers":[1,0,0,["rc",1],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
+    )
+};
+
+declare
 	%test:assertEquals("true")
 function stc:gt() {
 	semver:gt("2.0.0", "1.0.0")
+};
+
+declare
+	%test:assertEquals("true")
+function stc:gt-parsed() {
+	semver:gt-parsed(
+        map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
+    )
 };
 
 declare
@@ -81,8 +151,26 @@ function stc:eq() {
 
 declare
 	%test:assertEquals("true")
+function stc:eq-parsed() {
+	semver:eq-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
+    )
+};
+
+declare
+	%test:assertEquals("true")
 function stc:ne() {
 	semver:ne("1.0.0", "2.0.0")
+};
+
+declare
+	%test:assertEquals("true")
+function stc:ne-parsed() {
+	semver:ne-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
+        map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
+    )
 };
 
 declare
@@ -92,13 +180,40 @@ function stc:compare-eq() {
 };
 
 declare
+	%test:assertEquals("0")
+function stc:compare-eq-parsed() {
+	semver:compare-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
+    )
+};
+
+declare
 	%test:assertEquals("1")
 function stc:compare-gt() {
 	semver:compare("2.0.0", "1.0.0")
 };
 
 declare
+	%test:assertEquals("1")
+function stc:compare-gt-parsed() {
+	semver:compare-parsed(
+        map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
+    )
+};
+
+declare
 	%test:assertEquals("-1")
 function stc:compare-lt() {
 	semver:compare("1.0.0", "2.0.0")
+};
+
+declare
+	%test:assertEquals("-1")
+function stc:compare-lt-parsed() {
+	semver:compare-parsed(
+        map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
+        map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
+    )
 };

--- a/src/test/xquery/compare.xqm
+++ b/src/test/xquery/compare.xqm
@@ -34,67 +34,67 @@ declare namespace test = "http://exist-db.org/xquery/xqsuite";
 
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-major() {
-	semver:lt("1.0.0", "2.0.0")
+    semver:lt("1.0.0", "2.0.0")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-major-parsed() {
-	semver:lt-parsed(
+    semver:lt-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-minor() {
-	semver:lt("2.0.0", "2.1.0")
+    semver:lt("2.0.0", "2.1.0")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-minor-parsed() {
-	semver:lt-parsed(
+    semver:lt-parsed(
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
         map{"major":2,"minor":1,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,1,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-patch() {
-	semver:lt("2.1.0", "2.1.1")
+    semver:lt("2.1.0", "2.1.1")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-patch-parsed() {
-	semver:lt-parsed(
+    semver:lt-parsed(
         map{"major":2,"minor":1,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
         map{"major":2,"minor":1,"patch":1,"pre-release":[],"build-metadata":[],"identifiers":[2,1,1,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-pre-release() {
-	semver:lt("1.0.0-alpha", "1.0.0-alpha.1")
+    semver:lt("1.0.0-alpha", "1.0.0-alpha.1")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:lt-pre-release-parsed() {
-	semver:lt-parsed(
+    semver:lt-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":["alpha"],"build-metadata":[],"identifiers":[2,0,0,["alpha"],[]]}, 
         map{"major":1,"minor":0,"patch":0,"pre-release":["alpha",1],"build-metadata":[],"identifiers":[2,1,1,["alpha",1],[]]}
     )
 };
 
 declare
-	%test:assertEquals("true", "true", "true", "true", "true")
+    %test:assertEquals("true", "true", "true", "true", "true")
 function stc:lt-pre-release-dot() {
     semver:lt("1.0.0-alpha.1", "1.0.0-alpha.beta"),
     semver:lt("1.0.0-beta", "1.0.0-beta.2"),
@@ -104,7 +104,7 @@ function stc:lt-pre-release-dot() {
 };
 
 declare
-	%test:assertEquals("true", "true", "true", "true", "true")
+    %test:assertEquals("true", "true", "true", "true", "true")
 function stc:lt-pre-release-dot-parsed() {
     semver:lt-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":["alpha",1],"build-metadata":[],"identifiers":[1,0,0,["alpha",1],[]]}, 
@@ -129,90 +129,90 @@ function stc:lt-pre-release-dot-parsed() {
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:gt() {
-	semver:gt("2.0.0", "1.0.0")
+    semver:gt("2.0.0", "1.0.0")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:gt-parsed() {
-	semver:gt-parsed(
+    semver:gt-parsed(
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:eq() {
-	semver:eq("1.0.0", "1.0.0")
+    semver:eq("1.0.0", "1.0.0")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:eq-parsed() {
-	semver:eq-parsed(
+    semver:eq-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:ne() {
-	semver:ne("1.0.0", "2.0.0")
+    semver:ne("1.0.0", "2.0.0")
 };
 
 declare
-	%test:assertEquals("true")
+    %test:assertEquals("true")
 function stc:ne-parsed() {
-	semver:ne-parsed(
+    semver:ne-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("0")
+    %test:assertEquals("0")
 function stc:compare-eq() {
-	semver:compare("1.0.0", "1.0.0")
+    semver:compare("1.0.0", "1.0.0")
 };
 
 declare
-	%test:assertEquals("0")
+    %test:assertEquals("0")
 function stc:compare-eq-parsed() {
-	semver:compare-parsed(
+    semver:compare-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("1")
+    %test:assertEquals("1")
 function stc:compare-gt() {
-	semver:compare("2.0.0", "1.0.0")
+    semver:compare("2.0.0", "1.0.0")
 };
 
 declare
-	%test:assertEquals("1")
+    %test:assertEquals("1")
 function stc:compare-gt-parsed() {
-	semver:compare-parsed(
+    semver:compare-parsed(
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}, 
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}
     )
 };
 
 declare
-	%test:assertEquals("-1")
+    %test:assertEquals("-1")
 function stc:compare-lt() {
-	semver:compare("1.0.0", "2.0.0")
+    semver:compare("1.0.0", "2.0.0")
 };
 
 declare
-	%test:assertEquals("-1")
+    %test:assertEquals("-1")
 function stc:compare-lt-parsed() {
-	semver:compare-parsed(
+    semver:compare-parsed(
         map{"major":1,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[1,0,0,[],[]]}, 
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
     )

--- a/src/test/xquery/expath-package-semver-template.xqm
+++ b/src/test/xquery/expath-package-semver-template.xqm
@@ -1,0 +1,101 @@
+(:
+ : Copyright © 2022, Joe Wicentowski
+ : All rights reserved.
+ :
+ : Redistribution and use in source and binary forms, with or without
+ : modification, are permitted provided that the following conditions are met:
+ :     * Redistributions of source code must retain the above copyright
+ :       notice, this list of conditions and the following disclaimer.
+ :     * Redistributions in binary form must reproduce the above copyright
+ :       notice, this list of conditions and the following disclaimer in the
+ :       documentation and/or other materials provided with the distribution.
+ :     * Neither the name of the <organization> nor the
+ :       names of its contributors may be used to endorse or promote products
+ :       derived from this software without specific prior written permission.
+ :
+ : THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ : ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ : WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ : DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ : DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ : (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ : LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ : ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ : (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ : SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ :)
+xquery version "3.1";
+
+module namespace epst = "http://exist-db.org/xquery/semver/test/expath-package-semver-template";
+
+import module namespace semver = "http://exist-db.org/xquery/semver";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+
+declare
+    %test:assertTrue
+function epst:validate-major() {
+    semver:validate-expath-package-semver-template("2")
+};
+
+declare
+    %test:assertTrue
+function epst:validate-minor() {
+    semver:validate-expath-package-semver-template("2.3")
+};
+
+declare
+    %test:assertFalse
+function epst:validate-patch() {
+    semver:validate-expath-package-semver-template("2.3.4")
+};
+
+declare
+    %test:assertFalse
+function epst:validate-patch-zerp() {
+    semver:validate-expath-package-semver-template("2.3.0")
+};
+
+declare
+    %test:assertEquals("2.0.0")
+function epst:major-min() {
+    semver:resolve-expath-package-semver-template-min("2")
+    => semver:serialize-parsed()
+};
+
+declare
+    %test:assertEquals("3.0.0")
+function epst:major-max() {
+    semver:resolve-expath-package-semver-template-max("2")
+    => semver:serialize-parsed()
+};
+
+declare
+    %test:assertEquals("2.1.0")
+function epst:minor-min() {
+    semver:resolve-expath-package-semver-template-min("2.1")
+    => semver:serialize-parsed()
+};
+
+declare
+    %test:assertEquals("2.2.0")
+function epst:minor-max() {
+    semver:resolve-expath-package-semver-template-max("2.1")
+    => semver:serialize-parsed()
+};
+
+declare
+    %test:assertEquals("4.2.0", "4.7.1")
+function epst:public-repo-style-scenario() {
+    let $semver-min := "4.1.0"
+    let $semver-max := "4" 
+    let $available-versions := ("5.0.0", "4.1.0-SNAPSHOT", "6.0.1", "4.7.1", "3.3.0", "4.2.0")
+    let $semver-min-resolved := semver:resolve-if-expath-package-server-template-else-parse($semver-min, "min", true())
+    let $semver-max-resolved := semver:resolve-if-expath-package-server-template-else-parse($semver-max, "max", true())
+    let $available-versions-parsed-sorted := ($available-versions ! semver:parse(., true())) => semver:sort-parsed()
+    for $version in $available-versions-parsed-sorted
+    where semver:ge-parsed($version, $semver-min-resolved) and semver:lt-parsed($version, $semver-max-resolved)
+    return
+        semver:serialize-parsed($version)
+};

--- a/src/test/xquery/serialize.xqm
+++ b/src/test/xquery/serialize.xqm
@@ -34,7 +34,7 @@ declare namespace test = "http://exist-db.org/xquery/xqsuite";
 
 
 declare
-	%test:assertEquals("5.0.0-RC.5+201908061711")
+    %test:assertEquals("5.0.0-RC.5+201908061711")
 function stse:serialize() {
     semver:serialize(
         5,

--- a/src/test/xquery/sort.xqm
+++ b/src/test/xquery/sort.xqm
@@ -34,15 +34,15 @@ declare namespace test = "http://exist-db.org/xquery/xqsuite";
 
 
 declare
-	%test:assertEquals(
-	    "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
-	    "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11",
-	    "1.0.0-rc.1", "1.0.0", "2.0.0", "2.1.0", "2.1.1")
+    %test:assertEquals(
+        "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
+        "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11",
+        "1.0.0-rc.1", "1.0.0", "2.0.0", "2.1.0", "2.1.1")
 function sts:sort() {
-	let $versions :=
-	(
+    let $versions :=
+    (
         "1.0.0", "2.0.0", "2.1.0", "2.1.1", "1.0.0-alpha", "1.0.0-alpha.1",
-		"1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-beta.11", "1.0.0-beta.2", "1.0.0-rc.1"
+        "1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-beta.11", "1.0.0-beta.2", "1.0.0-rc.1"
     ) return
         semver:sort($versions)
 };
@@ -54,14 +54,14 @@ function sts:sort-with-coercion() {
 };
 
 declare
-	%test:assertEquals(
-	    "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
-	    "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11",
-	    "1.0.0-rc.1", "1.0.0", "1.1.1", "2.0.0", "2.1.0",
-	    "2.1.1", "2.2", "3")
+    %test:assertEquals(
+        "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
+        "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11",
+        "1.0.0-rc.1", "1.0.0", "1.1.1", "2.0.0", "2.1.0",
+        "2.1.1", "2.2", "3")
 function sts:sort-items-with-coercion() {
-	let $packages :=
-    	<packages>
+    let $packages :=
+        <packages>
             <package version="1.0.0"/>
             <package version="1.1.1"/>
             <package version="2.0.0"/>


### PR DESCRIPTION
This PR adds handling for resolving EXPath Package SemVer Templates - a feature needed to support the forthcoming fix to https://github.com/eXist-db/public-repo/issues/72. Tests have been added for the new functions. 

It also significantly simplifies the implementation of `semver:coerce` - by adding a new regex that can flexibly capture groups. All existing tests involving coercion pass.

It also adds missing variants of `semver:eq#3` and new variants of all of the comparison functions for working directly with parsed version maps (e.g., `semver:eq-parsed`), to avoid needless parsing/serializing when performing comparisons of already-parsed versions. 

It also deprecates `semver:compare#1`, renaming it as `semver:compare-parsed`, to follow the pattern of appending `-parsed` to the names of functions that handle parsed SemVer version maps.