### PR TITLE
🧪 test(expath-template): breaking pre-release

### DIFF
--- a/src/test/xquery/expath-package-semver-template.xqm
+++ b/src/test/xquery/expath-package-semver-template.xqm
@@ -90,7 +90,7 @@ declare
 function epst:public-repo-style-scenario() {
     let $semver-min := "4.1.0"
     let $semver-max := "4" 
-    let $available-versions := ("5.0.0", "4.1.0-SNAPSHOT", "6.0.1", "4.7.1", "3.3.0", "4.2.0")
+    let $available-versions := ("5.0.0", "5.0.0-SNAP", "4.1.0-SNAPSHOT", "6.0.1", "4.7.1", "3.3.0", "4.2.0")
     let $semver-min-resolved := semver:resolve-if-expath-package-server-template-else-parse($semver-min, "min", true())
     let $semver-max-resolved := semver:resolve-if-expath-package-server-template-else-parse($semver-max, "max", true())
     let $available-versions-parsed-sorted := ($available-versions ! semver:parse(., true())) => semver:sort-parsed()


### PR DESCRIPTION
add test for breaking pre-release

The test failure shows that `5.0.0-SNAP` is considered a valid version for the expath template `4`. It should not be, the specs omit discussing pre-release tags. But clearly state that versions `must be compatible`. this version is not. 



The failure on CI is intended https://github.com/eXist-db/semver.xq/actions/runs/3866836019/jobs/6591218315#step:6:54

Why the test passes on exist v4.2.0 https://github.com/eXist-db/semver.xq/actions/runs/3866836019/jobs/6591218279 
 beats me it should be consistent with the other runs