### PR TITLE
Fix semver:eq#3 ignoring $coerce parameter

### DIFF
--- a/src/main/xquery/semver.xqm
+++ b/src/main/xquery/semver.xqm
@@ -565,7 +565,7 @@ declare function semver:ge-parsed($parsed-v1 as map(*), $parsed-v2 as map(*)) as
  :  @return true if v1 is equal to v2
  :)
 declare function semver:eq($v1 as xs:string, $v2 as xs:string) as xs:boolean {
-    semver:compare($v1, $v2) eq 0
+    semver:eq($v1, $v2, false())
 };
 
 (:~ Test if v1 is equal to v2 (with an option to coerce invalid SemVer strings)
@@ -575,7 +575,7 @@ declare function semver:eq($v1 as xs:string, $v2 as xs:string) as xs:boolean {
  :  @return true if v1 is equal to v2
  :)
 declare function semver:eq($v1 as xs:string, $v2 as xs:string, $coerce as xs:boolean) as xs:boolean {
-    semver:compare($v1, $v2) eq 0
+    semver:compare($v1, $v2, $coerce) eq 0
 };
 
 (:~ Test if a parsed v1 is equal to a parsed v2

--- a/src/test/xquery/compare.xqm
+++ b/src/test/xquery/compare.xqm
@@ -217,3 +217,18 @@ function stc:compare-lt-parsed() {
         map{"major":2,"minor":0,"patch":0,"pre-release":[],"build-metadata":[],"identifiers":[2,0,0,[],[]]}
     )
 };
+
+(: Regression tests for bug where semver:eq/3 ignored $coerce and called
+   semver:compare/2 instead of semver:compare/3 :)
+
+declare
+    %test:assertTrue
+function stc:eq-coerce-non-semver() {
+    semver:eq("1.0", "1.0.0", true())
+};
+
+declare
+    %test:assertFalse
+function stc:eq-coerce-non-semver-not-equal() {
+    semver:eq("1.0", "2.0.0", true())
+};


### PR DESCRIPTION
## Summary

- `semver:eq#3` was calling `semver:compare#2` instead of `semver:compare#3`, causing the `$coerce` argument to be silently ignored. Calling `semver:eq("1.0", "1.0.0", true())` would throw an error instead of returning `true()`.
- `semver:eq#2` is updated to delegate to `semver:eq($v1, $v2, false())`, consistent with all other arity-2 comparison functions (`lt`, `le`, `gt`, `ge`, `ne`).
- Two regression tests added to `compare.xqm` covering the equal and not-equal cases with coercible non-SemVer strings.

## Test plan

- [x] `stc:eq-coerce-non-semver` — `semver:eq("1.0", "1.0.0", true())` returns `true()`
- [x] `stc:eq-coerce-non-semver-not-equal` — `semver:eq("1.0", "2.0.0", true())` returns `false()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)