### PR TITLE
Fix broken CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # semver.xq
 
-[![CI](https://github.com/eXist-db/semver.xq/workflows/CI/badge.svg)](https://github.com/eXist-db/semver.xq/actions?query=workflow%3ACI)
+[![CI](https://github.com/eXist-db/semver.xq/workflows/CI%20semver.xq/badge.svg)](https://github.com/eXist-db/semver.xq/actions?query=workflow%3A%22CI+semver.xq%22)
 [![License](https://img.shields.io/badge/license-BSD%203%20Clause-blue.svg)](http://opensource.org/licenses/BSD-3-Clause)
 
 Validate, compare, sort, parse, and serialize Semantic Versioning (SemVer) 2.0.0 version strings, using XQuery.


### PR DESCRIPTION
The CI badge was referencing a workflow named `CI`, but the actual workflow is named `CI semver.xq`. This caused the badge to show as broken/unknown.

## Changes
- Updated badge image URL: `workflows/CI/` → `workflows/CI%20semver.xq/`
- Updated badge link query: `workflow%3ACI` → `workflow%3A%22CI+semver.xq%22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)